### PR TITLE
Update for TOC 90001

### DIFF
--- a/EKPlates/EKPlates.lua
+++ b/EKPlates/EKPlates.lua
@@ -35,7 +35,7 @@ end
 
 -- Style for bar / 給各個條條兒的毛絨絨框體樣式
 local CreateBackdrop = function(parent, anchor, a)
-    local frame = CreateFrame("Frame", nil, parent)
+    local frame = CreateFrame("Frame", nil, parent, BackdropTemplateMixin and "BackdropTemplate")
 
 	local flvl = parent:GetFrameLevel()
 	if flvl - 1 >= 0 then frame:SetFrameLevel(flvl-1) end
@@ -926,7 +926,7 @@ local function UpdateNamePlateEvents(unitFrame)
 		displayedUnit = unitFrame.displayedUnit
 	end
 	
-	unitFrame:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", unit, displayedUnit)
+	unitFrame:RegisterUnitEvent("UNIT_HEALTH", unit, displayedUnit)
 	unitFrame:RegisterUnitEvent("UNIT_AURA", unit, displayedUnit)
 	unitFrame:RegisterUnitEvent("UNIT_THREAT_LIST_UPDATE", unit, displayedUnit)
 	
@@ -1056,7 +1056,7 @@ local function NamePlate_OnEvent(self, event, ...)
 	elseif event == "PLAYER_ENTERING_WORLD" then
 		UpdateAll(self)
 	elseif arg1 == self.unit or arg1 == self.displayedUnit then
-		if event == "UNIT_HEALTH_FREQUENT" then
+		if event == "UNIT_HEALTH" then
 			UpdateHealth(self)
 			UpdateSelectionHighlight(self)
 		elseif event == "UNIT_AURA" then
@@ -1169,7 +1169,7 @@ end
 --=============================================================--
 
 local function OnNamePlateCreated(namePlate)
-	namePlate.Pools = CreatePoolCollection() 
+	namePlate.Pools = CreateFramePoolCollection()
 	
 	if C.numberstyle then -- 数字样式
 		if C.castBar then
@@ -1188,7 +1188,7 @@ local function OnNamePlateCreated(namePlate)
 		namePlate.UnitFrame:SetAllPoints(namePlate)
 		namePlate.UnitFrame:SetFrameLevel(namePlate:GetFrameLevel())
 		namePlate.UnitFrame:Show()
-		namePlate.UnitFrame.Pools = CreatePoolCollection() 
+		namePlate.UnitFrame.Pools = CreateFramePoolCollection()
 		namePlate.UnitFrame.Pools:CreatePool("Frame", namePlate, "EKPlatesAuraIconTemplate")
 		
 		if C.classResourceShow and C.classResourceOn == "target" then
@@ -1202,7 +1202,7 @@ local function OnNamePlateCreated(namePlate)
 		namePlate.UnitFrame:SetAllPoints(namePlate)
 		namePlate.UnitFrame:SetFrameLevel(namePlate:GetFrameLevel())
 		namePlate.UnitFrame:Show()
-		namePlate.UnitFrame.Pools = CreatePoolCollection() 
+		namePlate.UnitFrame.Pools = CreateFramePoolCollection()
 		namePlate.UnitFrame.Pools:CreatePool("Frame", namePlate, "EKPlatesAuraIconTemplate")
 		
 		namePlate.UnitFrame.castBar:SetPoint("TOPLEFT", namePlate.UnitFrame.healthBar, "BOTTOMLEFT", 0, -4)

--- a/EKPlates/EKPlates.toc
+++ b/EKPlates/EKPlates.toc
@@ -1,11 +1,12 @@
-﻿## Interface: 80200
+﻿## Interface: 90001
 ## Title: |cff00ffffEK|rPlates
 ## Version: R3.2c
 ## Author: EK (Linodas@Illidan-US)
-## Notes: Nameplates. Credits to Paopao and Dawn.
+## Notes: (Shadowlands) Nameplates. Credits to Paopao and Dawn.
 
 ## X-Credits: Paopao, Dawn, Siweia, Rubgrsch
 
+LookAndFeel.lua
 EKPlates.xml
 Config.lua
 EKPlates.lua

--- a/EKPlates/EKPlates.xml
+++ b/EKPlates/EKPlates.xml
@@ -13,7 +13,7 @@
 		</Size>
 		<!-- 毛絨絨背景 -->
 		<Frames>
-			<Frame parentKey="bd">
+			<Frame parentKey="bd" mixin="BackdropTemplateMixin" inherits="BackdropTemplate">
 				<Anchors>
 					<Anchor point="TOPLEFT">
 						<Offset x="-3" y="3"/>
@@ -22,15 +22,6 @@
 						<Offset x="3" y="-3"/>
 					</Anchor>
 				</Anchors>
-				
-				<Backdrop bgFile="Interface\Buttons\WHITE8x8" edgeFile="Interface\AddOns\EKPlates\media\glow">
-					<EdgeSize>
-						<AbsValue val="3"/>
-					</EdgeSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 			</Frame>
 		</Frames>
 		<!-- 數值 -->
@@ -59,6 +50,7 @@
 				self:SetMinMaxValues(0, 1)
 				self.value:SetPoint("BOTTOMRIGHT", self, "TOPRIGHT", 0, -4) <!-- 數值文字在血量條上的錨點和座標 -->
 				self.bd:SetFrameLevel(self:GetParent():GetFrameLevel() == 0 and 1 or self:GetParent():GetFrameLevel() - 1)
+				self.bd:SetBackdrop(EKPLATES_BACKDROP_BD_3)
 				self.bd:SetBackdropColor(0.15, 0.15, 0.15)
 				self.bd:SetBackdropBorderColor(0, 0, 0)
 			</OnLoad>
@@ -74,7 +66,7 @@
 		</Size>
 		<!-- 毛絨絨背景 -->
 		<Frames>
-			<Frame parentKey="bd">
+			<Frame parentKey="bd" mixin="BackdropTemplateMixin" inherits="BackdropTemplate">
 				<Anchors>
 					<Anchor point="TOPLEFT">
 						<Offset x="-3" y="3"/>
@@ -83,15 +75,6 @@
 						<Offset x="3" y="-3"/>
 					</Anchor>
 				</Anchors>
-				
-				<Backdrop bgFile="Interface\Buttons\WHITE8x8" edgeFile="Interface\AddOns\EKPlates\media\glow">
-					<EdgeSize>
-						<AbsValue val="3"/>
-					</EdgeSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 			</Frame>
 		</Frames>
 		<!-- 數值 -->
@@ -118,6 +101,7 @@
 				self:SetMinMaxValues(0, 1)
 				self.value:SetPoint("LEFT", self,  0, -1) <!-- 高度3，血量百分比下移4，所以3 - 4 = -1 -->
 				self.bd:SetFrameLevel(self:GetParent():GetFrameLevel() == 0 and 1 or self:GetParent():GetFrameLevel() - 1)
+				self.bd:SetBackdrop(EKPLATES_BACKDROP_BD_3)
 				self.bd:SetBackdropColor(0.15, 0.15, 0.15)
 				self.bd:SetBackdropBorderColor(0, 0, 0)
 			</OnLoad>
@@ -159,7 +143,7 @@
 		
 		<!-- 毛絨絨背景 -->
 		<Frames>
-			<Frame parentKey="border">
+			<Frame parentKey="border" mixin="BackdropTemplateMixin" inherits="BackdropTemplate">
 				<Anchors>
 					<Anchor point="TOPLEFT">
 						<Offset x="-3" y="3"/>
@@ -168,15 +152,6 @@
 						<Offset x="3" y="-3"/>
 					</Anchor>
 				</Anchors>
-				
-				<Backdrop bgFile="Interface\Buttons\WHITE8x8" edgeFile="Interface\AddOns\EKPlates\media\glow">
-					<EdgeSize>
-						<AbsValue val="3"/>
-					</EdgeSize>
-					<BackgroundInsets>
-						<AbsInset left="3" right="3" top="3" bottom="3"/>
-					</BackgroundInsets>
-				</Backdrop>
 			</Frame>
 		</Frames>
 		
@@ -226,6 +201,7 @@
 		<Scripts>
 			<OnLoad>
 				self.border:SetFrameLevel(self:GetParent():GetFrameLevel() == 0 and 1 or self:GetParent():GetFrameLevel() - 1)
+				self.border:SetBackdrop(EKPLATES_BACKDROP_BD_3)
 				self.border:SetBackdropColor(0.15, 0.15, 0.15)
 				self.border:SetBackdropBorderColor(0, 0, 0)
 				
@@ -252,7 +228,7 @@
 		</Size>
 		<!-- 邊框 -->
 		<Frames>
-			<Frame parentKey="border">
+			<Frame parentKey="border" mixin="BackdropTemplateMixin" inherits="BackdropTemplate">
 				<Anchors>
 					<Anchor point="TOPLEFT">
 						<Offset x="-1" y="1"/>
@@ -261,14 +237,6 @@
 						<Offset x="1" y="-1"/>
 					</Anchor>
 				</Anchors>
-				<Backdrop bgFile="Interface\Buttons\WHITE8x8" edgeFile="Interface\Buttons\WHITE8x8">
-					<EdgeSize>
-						<AbsValue val="1"/>
-					</EdgeSize>
-					<BackgroundInsets>
-						<AbsInset left="1" right="1" top="1" bottom="1"/>
-					</BackgroundInsets>
-				</Backdrop>
 			</Frame>
 		</Frames>
 		
@@ -323,6 +291,7 @@
 		<Scripts>
 			<OnLoad>
 				self.border:SetFrameLevel(self:GetParent():GetFrameLevel() == 0 and 1 or self:GetParent():GetFrameLevel() - 1)
+				self.border:SetBackdrop(EKPLATES_BACKDROP_BD_1)
 				self.border:SetBackdropColor(0.15, 0.15, 0.15)
 				self.border:SetBackdropBorderColor(0, 0, 0)
 				self.Spark:SetAlpha(0)
@@ -436,7 +405,7 @@
 
 	<!-- 數字模式，圖示施法條 -->
 	
-	<Button name = "EKPlatesNumberStyleNameplateTemplate" setAllPoints="true" virtual="true">
+	<Button name="EKPlatesNumberStyleNameplateTemplate" mixin="BackdropTemplateMixin" inherits="BackdropTemplate" setAllPoints="true" virtual="true">
 		<Layers>
 			<Layer level="OVERLAY">
 				<!-- 血量百分比 -->

--- a/EKPlates/LookAndFeel.lua
+++ b/EKPlates/LookAndFeel.lua
@@ -1,0 +1,14 @@
+-- Backdrops
+EKPLATES_BACKDROP_BD_1 = {
+    bgFile="Interface\\Buttons\\WHITE8x8",
+	edgeFile = "Interface\\AddOns\\EKPlates\\media\\glow",
+	edgeSize = 1,
+	insets = {  left = 1, right = 1, top = 1, bottom = 1 },
+};
+
+EKPLATES_BACKDROP_BD_3 = {
+    bgFile="Interface\\Buttons\\WHITE8x8",
+	edgeFile = "Interface\\AddOns\\EKPlates\\media\\glow",
+	edgeSize = 3,
+	insets = {  left = 3, right = 3, top = 3, bottom = 3 },
+};


### PR DESCRIPTION
EKPlates doesn't work in the Shadowlands Beta. Let's fix that!

These fixes are based on the unofficial patch notes in https://github.com/Stanzilla/WoWUIBugs/wiki/9.0.1-Consolidated-UI-Changes#backdrop-system-changes

Versions tested:
- PTR
- Current release (for backwards compatability)

The current release will display a couple of LUA errors related to the BackdropTemplate
and BackdropTemplateMixin classes not existing.

Verified:
* Number style works fine
* Bar style works fine
* Bar and text casting work fine